### PR TITLE
Keep the color of parts of card in admin panel symmetric 

### DIFF
--- a/src/app/layout/feature/admin-layout/admin-layout.component.html
+++ b/src/app/layout/feature/admin-layout/admin-layout.component.html
@@ -3,7 +3,7 @@
     <div class="col-lg-3 col-md-6 col-sm-10 col-xs-12">
       <mat-card class="card-info color-green">
         <div class="row card-logo-icon">
-          <mat-card class="color-red">
+          <mat-card class="color-green">
             <mat-icon class="card-icon" mat-button>all_inbox</mat-icon>
           </mat-card>
         </div>
@@ -16,7 +16,7 @@
     <div class="col-lg-3 col-md-6 col-sm-10 col-xs-12">
       <mat-card class="card-info color-red">
         <div class="row card-logo-icon">
-          <mat-card class="color-green">
+          <mat-card class="color-red">
             <mat-icon class="card-icon" mat-button>all_inbox</mat-icon>
           </mat-card>
         </div>
@@ -29,7 +29,7 @@
     <div class="col-lg-3 col-md-6 col-sm-10 col-xs-12">
       <mat-card class="card-info color-skyblue">
         <div class="row card-logo-icon">
-          <mat-card class="color-orange">
+          <mat-card class="color-skyblue">
             <mat-icon class="card-icon" mat-button>bubble_chart</mat-icon>
           </mat-card>
         </div>
@@ -42,7 +42,7 @@
     <div class="col-lg-3 col-md-6 col-sm-10 col-xs-12">
       <mat-card class="card-info color-orange">
         <div class="row card-logo-icon">
-          <mat-card class="color-skyblue">
+          <mat-card class="color-orange">
             <mat-icon class="card-icon" mat-button>attach_money</mat-icon>
           </mat-card>
         </div>


### PR DESCRIPTION
Admin panel will look like this with the changes:

![Screen Shot 2019-04-06 at 10 58 50 PM](https://user-images.githubusercontent.com/9162661/55675839-9481a400-58c0-11e9-99d7-f2c8771e57c8.png)
